### PR TITLE
fix(security): Patch CVE-2025-55182 - Update Next.js

### DIFF
--- a/zk-study-web/package.json
+++ b/zk-study-web/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.1.6"
+    "next": "15.3.0"
   },
   "devDependencies": {
     "typescript": "^5",
@@ -21,7 +21,7 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "eslint": "^9",
-    "eslint-config-next": "15.1.6",
+    "eslint-config-next": "15.3.0",
     "@eslint/eslintrc": "^3"
   }
 }


### PR DESCRIPTION
## Summary
- Update Next.js from `15.1.6` to `15.3.0`
- Update eslint-config-next to `15.3.0`

## Security Issue
This PR addresses **CVE-2025-55182 (React2Shell)**, a critical Remote Code Execution vulnerability in React and Next.js.

## Changes
- `zk-study-web/package.json`: Updated Next.js and eslint-config-next versions

## Test Plan
- [ ] Run `npm install` to update dependencies
- [ ] Run `npm run build` to verify build succeeds
- [ ] Run `npm audit` to confirm no remaining vulnerabilities

Closes #3