### PR TITLE
fix(security): Address multiple Dependabot security alerts

### DIFF
--- a/zk-study-web/package.json
+++ b/zk-study-web/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.0"
+    "next": "15.3.8"
   },
   "devDependencies": {
     "typescript": "^5",
@@ -21,7 +21,7 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "eslint": "^9",
-    "eslint-config-next": "15.3.0",
+    "eslint-config-next": "15.3.8",
     "@eslint/eslintrc": "^3"
   }
 }


### PR DESCRIPTION
## Summary
Updates Next.js to patch multiple critical and high severity vulnerabilities detected by Dependabot.

## Changes
- `zk-study-web/package.json`: Update Next.js from 15.3.0 to **15.3.8**

## Security Vulnerabilities Addressed

### Critical
- **CVE-2025-29927** - Authorization Bypass in Next.js Middleware
- **GHSA-9qr9-h5gf-34mp** - RCE in React flight protocol

### High
- **GHSA-mwv6-3258-q52c** - DoS with Server Components
- **CVE-2025-49826** - DoS via cache poisoning

### Medium
- **CVE-2025-55184** - Denial of Service
- **CVE-2025-55183** - Source Code Exposure
- **CVE-2025-57822** - SSRF via Middleware redirect
- **CVE-2025-57752** - Cache Key Confusion
- **CVE-2025-55173** - Content Injection

## References
- [Next.js Security Update: December 11, 2025](https://nextjs.org/blog/security-update-2025-12-11)
- [CVE-2025-66478 Advisory](https://nextjs.org/blog/CVE-2025-66478)

## Test Plan
- [ ] Run `npm install` to update dependencies
- [ ] Run `npm run build` to verify build succeeds
- [ ] Run `npm audit` to confirm no remaining vulnerabilities

Closes #5